### PR TITLE
fix: added ping functionality to comments and responses

### DIFF
--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -28,6 +28,8 @@ import { setDraftComments, setDraftResponses } from '../../data/slices';
 import { addComment, editComment } from '../../data/thunks';
 import messages from '../../messages';
 
+import { UserMentionPluginSlot } from '../../../../plugin-slots/UserMentionPluginSlot';
+
 const CommentEditor = ({
   comment,
   edit,
@@ -192,6 +194,7 @@ const CommentEditor = ({
               saveDraftContent(content);
             }}
           />
+          <UserMentionPluginSlot editor={editorRef.current} />
           {isFormikFieldInvalid('comment', {
             errors,
             touched,

--- a/src/discussions/post-comments/comments/comment/CommentEditor.jsx
+++ b/src/discussions/post-comments/comments/comment/CommentEditor.jsx
@@ -15,6 +15,7 @@ import { TinyMCEEditor } from '../../../../components';
 import FormikErrorFeedback from '../../../../components/FormikErrorFeedback';
 import PostPreviewPanel from '../../../../components/PostPreviewPanel';
 import useDispatchWithState from '../../../../data/hooks';
+import { UserMentionPluginSlot } from '../../../../plugin-slots/UserMentionPluginSlot';
 import DiscussionContext from '../../../common/context';
 import {
   selectModerationSettings,
@@ -27,8 +28,6 @@ import { useDraftContent } from '../../data/hooks';
 import { setDraftComments, setDraftResponses } from '../../data/slices';
 import { addComment, editComment } from '../../data/thunks';
 import messages from '../../messages';
-
-import { UserMentionPluginSlot } from '../../../../plugin-slots/UserMentionPluginSlot';
 
 const CommentEditor = ({
   comment,

--- a/src/discussions/posts/post-editor/PostEditor.jsx
+++ b/src/discussions/posts/post-editor/PostEditor.jsx
@@ -21,6 +21,7 @@ import FormikErrorFeedback from '../../../components/FormikErrorFeedback';
 import PostHelpPanel from '../../../components/PostHelpPanel';
 import PostPreviewPanel from '../../../components/PostPreviewPanel';
 import useDispatchWithState from '../../../data/hooks';
+import { UserMentionPluginSlot } from '../../../plugin-slots/UserMentionPluginSlot';
 import selectCourseCohorts from '../../cohorts/data/selectors';
 import fetchCourseCohorts from '../../cohorts/data/thunks';
 import DiscussionContext from '../../common/context';
@@ -50,8 +51,6 @@ import { selectThread } from '../data/selectors';
 import { createNewThread, fetchThread, updateExistingThread } from '../data/thunks';
 import messages from './messages';
 import PostTypeCard from './PostTypeCard';
-
-import { UserMentionPluginSlot } from '../../../plugin-slots/UserMentionPluginSlot';
 
 const PostEditor = ({
   editExisting,

--- a/src/plugin-slots/UserMentionPluginSlot/index.jsx
+++ b/src/plugin-slots/UserMentionPluginSlot/index.jsx
@@ -1,6 +1,9 @@
+import PropTypes from 'prop-types';
+
 import { PluginSlot } from '@openedx/frontend-plugin-framework/dist';
-import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+
 import { getConfig } from '@edx/frontend-platform';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 
 export const UserMentionPluginSlot = ({ editor }) => (
   <PluginSlot
@@ -13,3 +16,8 @@ export const UserMentionPluginSlot = ({ editor }) => (
     }}
   />
 );
+
+UserMentionPluginSlot.propTypes = {
+  // eslint-disable-next-line react/forbid-prop-types
+  editor: PropTypes.any.isRequired,
+};


### PR DESCRIPTION
Issue: https://github.com/edly-io/edly-team/issues/377

This PR:
- Adds the `UserMentionPluginSlot` to the comment editor so that the ping functionality can be used in the comments and responses as well. 
- Fixes lint issues in the following files: `CommentEditor.jsx`, `PostEditor.jsx`, and `UserMentionPluginSlot/index.jsx`.